### PR TITLE
Wrong axes in OBB intersection tests?

### DIFF
--- a/Code/Geometry3D.cpp
+++ b/Code/Geometry3D.cpp
@@ -361,9 +361,9 @@ bool AABBOBB(const AABB& aabb, const OBB& obb) {
 	};
 
 	for (int i = 0; i < 3; ++i) { // Fill out rest of axis
-		test[6 + i * 3 + 0] = Cross(test[i], test[0]);
-		test[6 + i * 3 + 1] = Cross(test[i], test[1]);
-		test[6 + i * 3 + 2] = Cross(test[i], test[2]);
+		test[6 + i * 3 + 0] = Cross(test[i], test[3]);
+		test[6 + i * 3 + 1] = Cross(test[i], test[4]);
+		test[6 + i * 3 + 2] = Cross(test[i], test[5]);
 	}
 
 	for (int i = 0; i < 15; ++i) {

--- a/Code/Geometry3D.cpp
+++ b/Code/Geometry3D.cpp
@@ -504,9 +504,9 @@ bool OBBOBB(const OBB& obb1, const OBB& obb2) {
 	};
 
 	for (int i = 0; i < 3; ++i) { // Fill out rest of axis
-		test[6 + i * 3 + 0] = Cross(test[i], test[0]);
-		test[6 + i * 3 + 1] = Cross(test[i], test[1]);
-		test[6 + i * 3 + 2] = Cross(test[i], test[2]);
+		test[6 + i * 3 + 0] = Cross(test[i], test[3]);
+		test[6 + i * 3 + 1] = Cross(test[i], test[4]);
+		test[6 + i * 3 + 2] = Cross(test[i], test[5]);
 	}
 
 	for (int i = 0; i < 15; ++i) {


### PR DESCRIPTION
The current code tests these axes:
```
Cross(test[0], test[0])
Cross(test[0], test[1])
Cross(test[0], test[2])

Cross(test[1], test[0])
Cross(test[1], test[1])
Cross(test[1], test[2])

Cross(test[2], test[0])
Cross(test[2], test[1])
Cross(test[2], test[2])
```

while it should actually check these (all combinations of the axes of both boxes):
```
Cross(test[0], test[3])
Cross(test[0], test[4])
Cross(test[0], test[5])

Cross(test[1], test[3])
Cross(test[1], test[4])
Cross(test[1], test[5])

Cross(test[2], test[3])
Cross(test[2], test[4])
Cross(test[2], test[5])
```